### PR TITLE
add test suite, GitHub Actions CI, and minor cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -v --cov=data --cov=last_fm --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 ## To run locally:
 
-`git clone https://github.com/andrewgarmon/record_club.git`
+```
+git clone https://github.com/andrewgarmon/record_club.git
+pip install -r requirements.txt        # or pip3
+streamlit run Records_and_Rebuttals.py
+```
 
-`pip install -r requirements.txt` (or pip3)
+## Running the tests
 
-`streamlit run main.py`
+```
+pip install -r requirements-dev.txt
+pytest
+```
+
+Tests also run automatically on every push / pull request via GitHub Actions
+(see `.github/workflows/ci.yml`).
 
 ## Streamlit Community Cloud Deployment:
 http://record-club.streamlit.app

--- a/data.py
+++ b/data.py
@@ -98,7 +98,7 @@ def build_deviation_df(reviews_df: pd.DataFrame) -> pd.DataFrame:
                 )
                 similarity_matrix.loc[user1, user2] = deviation_metric.round(2)
 
-    similarity_matrix = similarity_matrix.fillna(0).infer_objects(copy=False)
+    similarity_matrix = similarity_matrix.fillna(0).infer_objects()
     similarity_matrix.loc['average'] = similarity_matrix.mean().round(2)
     return similarity_matrix
 

--- a/pages/Listeners.py
+++ b/pages/Listeners.py
@@ -1,5 +1,5 @@
 import streamlit as st
-import pandas as pd
+
 import last_fm
 
 
@@ -23,26 +23,17 @@ def _display_scores_given(listener_requester_df, reviews_df, listener):
         "score"
     ].mean()
     given_scores["Average"] = avg_score_given
-    valid_scores = given_scores.loc[listener].dropna()
 
-    sorted_columns = valid_scores.argsort()[::-1]  # Sort remaining valid scores
+    valid_scores = given_scores.loc[listener].dropna()
+    sorted_columns = valid_scores.argsort()[::-1]
     sorted_given_scores = given_scores[
         valid_scores.index[sorted_columns]
     ].reset_index(drop=True)
 
-    # Calculate the average score the listener gave
-    avg_score_given = reviews_df[reviews_df["listener"] == listener][
-        "score"
-    ].mean()
-    # sorted_given_scores["Average"] = avg_score_given
-
     styled_given_scores = sorted_given_scores.style.format(
         precision=2
     ).background_gradient(axis=1, cmap="RdYlGn")
-    st.dataframe(
-        styled_given_scores,
-        hide_index=True,
-    )
+    st.dataframe(styled_given_scores, hide_index=True)
 
 
 def _display_scores_received(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    # Streamlit's caching decorators warn when run outside the app; harmless.
+    "ignore::UserWarning:streamlit.runtime.caching",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-cov==6.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for the test suite.
+
+Adds the project root to ``sys.path`` so tests can import the top-level
+modules (``data``, ``last_fm``) the same way the Streamlit app does.
+"""
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def raw_sheet_df() -> pd.DataFrame:
+    """A DataFrame shaped like the Google Sheet ``load_sheet`` returns.
+
+    The real sheet has an unnamed whitespace-only date column, three
+    columns per listener (``Name``, ``Name.1``, ``Name.2`` for score,
+    favorite track, least favorite track), and an ``Average`` column at
+    the end.
+    """
+    return pd.DataFrame(
+        {
+            " ": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            "Requester": ["Alice", "Bob", "Carol"],
+            "Artist": ["Beatles", "Stones", "Zeppelin"],
+            "Album": ["Abbey Road", "Let It Bleed", "IV"],
+            "Release Year": [1969, 1969, 1971],
+            "Decade": ["60s", "60s", "70s"],
+            "Alice": [9, 8, 7],
+            "Alice.1": ["Come Together", "Gimme Shelter", "Black Dog"],
+            "Alice.2": ["Octopus's Garden", None, "Four Sticks"],
+            "Bob": [7, 9, 10],
+            "Bob.1": ["Something", "Monkey Man", "Stairway to Heaven"],
+            "Bob.2": [None, None, None],
+            "Carol": [8, 7, 9],
+            "Carol.1": ["Here Comes the Sun", "Midnight Rambler", "Rock and Roll"],
+            "Carol.2": [None, None, None],
+            "Average": [8.0, 8.0, 8.67],
+        }
+    )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,191 @@
+"""Tests for the pure data-munging helpers in ``data.py``."""
+import numpy as np
+import pandas as pd
+import pytest
+
+import data
+
+
+class TestNormalizeColumns:
+    def test_renames_whitespace_column_to_date(self):
+        df = pd.DataFrame({" ": ["2024-01-01"], "Artist": ["Beatles"]})
+        result = data._normalize_columns(df)
+        assert "Date" in result.columns
+        assert " " not in result.columns
+
+    def test_leaves_existing_date_column_alone(self):
+        df = pd.DataFrame(
+            {"Date": ["2024-01-01"], " ": ["junk"], "Artist": ["Beatles"]}
+        )
+        result = data._normalize_columns(df)
+        # Existing Date column wins, whitespace column is untouched.
+        assert list(result.columns) == ["Date", " ", "Artist"]
+
+    def test_noop_when_no_whitespace_column(self):
+        df = pd.DataFrame({"Artist": ["Beatles"], "Album": ["Abbey Road"]})
+        result = data._normalize_columns(df)
+        pd.testing.assert_frame_equal(result, df)
+
+
+class TestGetListeners:
+    def test_detects_listeners_between_metadata_and_average(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        assert data.get_listeners(df) == ["Alice", "Bob", "Carol"]
+
+    def test_excludes_favorite_and_least_favorite_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        assert not any(name.endswith((".1", ".2")) for name in listeners)
+
+    def test_excludes_unnamed_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.insert(len(df.columns) - 1, "Unnamed: 42", [None] * len(df))
+        listeners = data.get_listeners(df)
+        assert "Unnamed: 42" not in listeners
+
+    def test_raises_if_average_column_missing(self):
+        df = pd.DataFrame({"Artist": ["Beatles"], "Alice": [8]})
+        with pytest.raises(ValueError):
+            data.get_listeners(df)
+
+
+class TestBuildAlbumsDf:
+    def test_selects_and_renames_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        albums = data.build_albums_df(df)
+        assert list(albums.columns) == [
+            "artist",
+            "album",
+            "requester",
+            "date",
+            "release_year",
+        ]
+        assert len(albums) == 3
+        assert albums.iloc[0]["artist"] == "Beatles"
+        assert albums.iloc[0]["album"] == "Abbey Road"
+
+    def test_works_without_release_year_column(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df).drop(columns=["Release Year"])
+        albums = data.build_albums_df(df)
+        assert "release_year" not in albums.columns
+        assert "artist" in albums.columns
+
+
+class TestBuildReviewsDf:
+    def test_flattens_wide_sheet_into_long_reviews(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        reviews = data.build_reviews_df(df, listeners)
+
+        # 3 albums x 3 listeners = 9 reviews
+        assert len(reviews) == 9
+        assert set(reviews.columns) == {
+            "listener",
+            "artist",
+            "album",
+            "score",
+            "favorite_track",
+            "least_favorite_track",
+        }
+
+    def test_captures_favorite_and_least_favorite_tracks(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+
+        alice_zep = reviews[
+            (reviews["listener"] == "Alice") & (reviews["album"] == "IV")
+        ].iloc[0]
+        assert alice_zep["favorite_track"] == "Black Dog"
+        assert alice_zep["least_favorite_track"] == "Four Sticks"
+
+    def test_skips_rows_with_missing_artist_or_album(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.loc[1, "Artist"] = None
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        assert "Let It Bleed" not in reviews["album"].tolist()
+
+    def test_skips_reviews_with_null_scores(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.loc[0, "Alice"] = None
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        alice_abbey = reviews[
+            (reviews["listener"] == "Alice") & (reviews["album"] == "Abbey Road")
+        ]
+        assert alice_abbey.empty
+
+
+class TestBuildDeviationDf:
+    def test_returns_square_matrix_plus_average_row(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        listeners = sorted(reviews["listener"].unique())
+        assert sorted(deviation.columns.tolist()) == listeners
+        assert "average" in deviation.index
+        # The non-average rows are the listener names.
+        non_avg = [i for i in deviation.index if i != "average"]
+        assert sorted(non_avg) == listeners
+
+    def test_diagonal_is_zero(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        for listener in reviews["listener"].unique():
+            assert deviation.loc[listener, listener] == 0
+
+    def test_deviation_is_symmetric(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        listeners = reviews["listener"].unique()
+        for a in listeners:
+            for b in listeners:
+                assert deviation.loc[a, b] == deviation.loc[b, a]
+
+    def test_known_rmse_value(self):
+        # Alice and Bob both rate two albums; Alice=[10, 6], Bob=[8, 8].
+        # Differences: 2, -2. RMSE = sqrt((4+4)/2) = 2.0
+        reviews = pd.DataFrame(
+            [
+                {"listener": "Alice", "artist": "X", "album": "A", "score": 10},
+                {"listener": "Alice", "artist": "X", "album": "B", "score": 6},
+                {"listener": "Bob", "artist": "X", "album": "A", "score": 8},
+                {"listener": "Bob", "artist": "X", "album": "B", "score": 8},
+            ]
+        )
+        deviation = data.build_deviation_df(reviews)
+        assert deviation.loc["Alice", "Bob"] == pytest.approx(2.0)
+
+
+class TestBuildListenerRequesterDf:
+    def test_produces_pivot_keyed_by_listener_and_requester(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        reviews = data.build_reviews_df(df, listeners)
+        albums = data.build_albums_df(df)
+
+        pivot = data.build_listener_requester_df(reviews, albums)
+
+        assert pivot.index.name == "listener"
+        assert pivot.columns.name == "requester"
+        assert set(pivot.index) <= {"Alice", "Bob", "Carol"}
+        assert set(pivot.columns) <= {"Alice", "Bob", "Carol"}
+
+    def test_values_are_mean_scores_rounded_to_one_decimal(self):
+        reviews = pd.DataFrame(
+            [
+                {"listener": "Alice", "artist": "X", "album": "A", "score": 9},
+                {"listener": "Alice", "artist": "X", "album": "B", "score": 6},
+            ]
+        )
+        albums = pd.DataFrame(
+            [
+                {"artist": "X", "album": "A", "requester": "Bob"},
+                {"artist": "X", "album": "B", "requester": "Bob"},
+            ]
+        )
+        pivot = data.build_listener_requester_df(reviews, albums)
+        assert pivot.loc["Alice", "Bob"] == pytest.approx(7.5)

--- a/tests/test_last_fm.py
+++ b/tests/test_last_fm.py
@@ -1,0 +1,155 @@
+"""Tests for the Last.fm API client and ``Album`` response parser."""
+from unittest.mock import patch, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import last_fm
+
+
+@pytest.fixture
+def album_response():
+    """A trimmed-down copy of a real ``album.getinfo`` response."""
+    return {
+        "album": {
+            "artist": "Radiohead",
+            "name": "OK Computer",
+            "image": [
+                {"#text": "https://img/small.png", "size": "small"},
+                {"#text": "https://img/medium.png", "size": "medium"},
+                {"#text": "https://img/large.png", "size": "large"},
+                {"#text": "https://img/xl.png", "size": "extralarge"},
+            ],
+            "tracks": {
+                "track": [
+                    {
+                        "name": "Airbag",
+                        "duration": "284",
+                        "@attr": {"rank": "1"},
+                    },
+                    {
+                        "name": "Paranoid Android",
+                        "duration": "383",
+                        "@attr": {"rank": "2"},
+                    },
+                ]
+            },
+            "tags": {
+                "tag": [
+                    {"name": "alternative"},
+                    {"name": "rock"},
+                ]
+            },
+            "listeners": "1234567",
+            "playcount": "98765432",
+        }
+    }
+
+
+class TestAlbum:
+    def test_parses_basic_fields(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.artist == "Radiohead"
+        assert album.title == "OK Computer"
+        assert album.listeners == "1234567"
+        assert album.playcount == "98765432"
+
+    def test_picks_large_image(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.image_url == "https://img/large.png"
+
+    def test_parses_tracks_with_rank_and_duration(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.tracks == [
+            {"title": "Airbag", "duration": "284", "track_number": "1"},
+            {
+                "title": "Paranoid Android",
+                "duration": "383",
+                "track_number": "2",
+            },
+        ]
+
+    def test_parses_tags(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.tags == [{"name": "alternative"}, {"name": "rock"}]
+
+    def test_handles_missing_tags(self, album_response):
+        album_response["album"].pop("tags")
+        album = last_fm.Album(album_response)
+        assert album.tags == []
+
+    def test_handles_empty_response(self):
+        album = last_fm.Album({})
+        assert album.artist is None
+        assert album.title is None
+        assert album.tracks == []
+        assert album.tags == []
+        assert album.image_url is None
+
+    def test_image_url_is_none_when_no_large_image(self, album_response):
+        album_response["album"]["image"] = [
+            {"#text": "https://img/small.png", "size": "small"}
+        ]
+        album = last_fm.Album(album_response)
+        assert album.image_url is None
+
+
+class TestLastFmClient:
+    def test_build_url_adds_api_key_method_and_format(self):
+        client = last_fm.LastFmClient("secret-key")
+        url = client._build_url(
+            "album.getinfo", {"artist": "Radiohead", "album": "OK Computer"}
+        )
+
+        parsed = urlparse(url)
+        assert parsed.scheme == "https"
+        assert parsed.netloc == "ws.audioscrobbler.com"
+        assert parsed.path == "/2.0/"
+
+        qs = parse_qs(parsed.query)
+        assert qs["api_key"] == ["secret-key"]
+        assert qs["method"] == ["album.getinfo"]
+        assert qs["format"] == ["json"]
+        assert qs["artist"] == ["Radiohead"]
+        assert qs["album"] == ["OK Computer"]
+
+    def test_get_album_calls_api_and_returns_album(self, album_response):
+        client = last_fm.LastFmClient("k")
+        with patch.object(last_fm, "_make_call", return_value=album_response) as mk:
+            album = client.get_album("Radiohead", "OK Computer")
+
+        mk.assert_called_once()
+        called_url = mk.call_args[0][0]
+        qs = parse_qs(urlparse(called_url).query)
+        assert qs["artist"] == ["Radiohead"]
+        assert qs["album"] == ["OK Computer"]
+        assert qs["autocorrect"] == ["1"]
+        assert isinstance(album, last_fm.Album)
+        assert album.title == "OK Computer"
+
+    def test_get_album_returns_none_when_api_returns_none(self):
+        client = last_fm.LastFmClient("k")
+        with patch.object(last_fm, "_make_call", return_value=None):
+            assert client.get_album("X", "Y") is None
+
+    def test_make_call_raises_for_status(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("boom")
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            with pytest.raises(Exception, match="boom"):
+                last_fm._make_call("https://example.com")
+
+    def test_make_call_returns_parsed_json(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status.return_value = None
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            assert last_fm._make_call("https://example.com") == {"ok": True}
+
+    def test_get_album_art_fetches_image_bytes(self, album_response):
+        album = last_fm.Album(album_response)
+        mock_response = MagicMock()
+        mock_response.content = b"\x89PNG fake bytes"
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            buf = album.get_album_art()
+        assert buf.read() == b"\x89PNG fake bytes"


### PR DESCRIPTION
Set up a baseline of automated tests before adding new features:

- tests/test_data.py covers all pure helpers in data.py (column
  normalization, listener detection, wide->long review reshaping,
  deviation matrix, and the listener/requester pivot).
- tests/test_last_fm.py covers Album response parsing and the
  LastFmClient URL builder / HTTP layer with mocked requests.
- pyproject.toml configures pytest.
- requirements-dev.txt pulls in pytest + pytest-cov on top of the
  runtime deps.
- .github/workflows/ci.yml runs the suite with coverage on Python
  3.11 and 3.12 for every push and PR to main.

Cleanups noticed along the way:
- data.py: drop deprecated copy=False kwarg on infer_objects.
- pages/Listeners.py: remove duplicate avg_score_given calculation,
  stale commented line, and unused pandas import.
- README.md: correct the `streamlit run` entrypoint (was main.py,
  should be Records_and_Rebuttals.py) and document how to run tests.