### PR TITLE
Add genre stats powered by Last.fm album tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        run: pytest -v --cov=data --cov=last_fm --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -2,11 +2,21 @@
 
 ## To run locally:
 
-`git clone https://github.com/andrewgarmon/record_club.git`
+```
+git clone https://github.com/andrewgarmon/record_club.git
+pip install -r requirements.txt        # or pip3
+streamlit run Records_and_Rebuttals.py
+```
 
-`pip install -r requirements.txt` (or pip3)
+## Running the tests
 
-`streamlit run main.py`
+```
+pip install -r requirements-dev.txt
+pytest
+```
+
+Tests also run automatically on every push / pull request via GitHub Actions
+(see `.github/workflows/ci.yml`).
 
 ## Streamlit Community Cloud Deployment:
 http://record-club.streamlit.app

--- a/Records_and_Rebuttals.py
+++ b/Records_and_Rebuttals.py
@@ -111,6 +111,9 @@ st.session_state["deviation_df"] = data.build_deviation_df(st.session_state["rev
 st.session_state["listener_requester_df"] = data.build_listener_requester_df(
     st.session_state["reviews_df"], st.session_state["albums_df"]
 )
+st.session_state["album_stats_df"] = data.build_album_stats_df(
+    st.session_state["reviews_df"], st.session_state["albums_df"]
+)
 
 display_summary_tables()
 display_listener_analysis()

--- a/Records_and_Rebuttals.py
+++ b/Records_and_Rebuttals.py
@@ -100,20 +100,8 @@ def display_top_albums(lf_client: last_fm.LastFmClient) -> None:
 
 
 st.set_page_config(page_title='Records and Rebuttals')
-sheets_doc_id = st.secrets['SHEETS_DOC_ID']
-df = data.load_sheet(sheets_doc_id)
+data.ensure_session_state(st.secrets['SHEETS_DOC_ID'])
 lf_client = last_fm.LastFmClient(st.secrets['LAST_FM_API_KEY'])
-
-listeners = data.get_listeners(df)
-st.session_state["albums_df"] = data.build_albums_df(df)
-st.session_state["reviews_df"] = data.build_reviews_df(df, listeners)
-st.session_state["deviation_df"] = data.build_deviation_df(st.session_state["reviews_df"])
-st.session_state["listener_requester_df"] = data.build_listener_requester_df(
-    st.session_state["reviews_df"], st.session_state["albums_df"]
-)
-st.session_state["album_stats_df"] = data.build_album_stats_df(
-    st.session_state["reviews_df"], st.session_state["albums_df"]
-)
 
 display_summary_tables()
 display_listener_analysis()

--- a/data.py
+++ b/data.py
@@ -98,7 +98,7 @@ def build_deviation_df(reviews_df: pd.DataFrame) -> pd.DataFrame:
                 )
                 similarity_matrix.loc[user1, user2] = deviation_metric.round(2)
 
-    similarity_matrix = similarity_matrix.fillna(0).infer_objects(copy=False)
+    similarity_matrix = similarity_matrix.fillna(0).infer_objects()
     similarity_matrix.loc['average'] = similarity_matrix.mean().round(2)
     return similarity_matrix
 

--- a/data.py
+++ b/data.py
@@ -40,6 +40,14 @@ def get_listeners(df: pd.DataFrame) -> list[str]:
     ]
 
 
+def _year_to_decade(year) -> str | None:
+    try:
+        y = int(year)
+    except (TypeError, ValueError):
+        return None
+    return f"{(y // 10) * 10}s"
+
+
 def build_albums_df(df: pd.DataFrame) -> pd.DataFrame:
     columns = {
         'Artist': 'artist',
@@ -49,8 +57,39 @@ def build_albums_df(df: pd.DataFrame) -> pd.DataFrame:
     }
     if 'Release Year' in df.columns:
         columns['Release Year'] = 'release_year'
+    if 'Decade' in df.columns:
+        columns['Decade'] = 'decade'
     available = {k: v for k, v in columns.items() if k in df.columns}
-    return df[list(available.keys())].rename(columns=available).reset_index(drop=True)
+    result = (
+        df[list(available.keys())].rename(columns=available).reset_index(drop=True)
+    )
+    if 'decade' not in result.columns and 'release_year' in result.columns:
+        result['decade'] = result['release_year'].apply(_year_to_decade)
+    if 'date' in result.columns:
+        result['date'] = pd.to_datetime(result['date'], errors='coerce')
+    return result
+
+
+def build_album_stats_df(
+    reviews_df: pd.DataFrame, albums_df: pd.DataFrame
+) -> pd.DataFrame:
+    """Per-album score aggregates joined with album metadata.
+
+    Columns: artist, album, requester, date, release_year, decade (when
+    available), plus mean/median/std/min/max/count.
+    """
+    if reviews_df.empty:
+        return pd.DataFrame()
+    stats = (
+        reviews_df.groupby(['artist', 'album'])['score']
+        .agg(['mean', 'median', 'std', 'min', 'max', 'count'])
+        .reset_index()
+    )
+    stats['std'] = stats['std'].fillna(0)
+    merged = stats.merge(albums_df, on=['artist', 'album'], how='left')
+    return merged.round(
+        {'mean': 2, 'median': 2, 'std': 2, 'min': 2, 'max': 2}
+    )
 
 
 def build_reviews_df(df: pd.DataFrame, listeners: list[str]) -> pd.DataFrame:

--- a/data.py
+++ b/data.py
@@ -153,3 +153,36 @@ def build_listener_requester_df(
     )
     avg_scores_df['score'] = avg_scores_df['score'].round(1)
     return avg_scores_df.pivot(index='listener', columns='requester', values='score')
+
+
+def ensure_session_state(sheets_doc_id: str) -> None:
+    """Populate session state with all derived dataframes.
+
+    Safe to call from any page: if everything's already loaded we return
+    immediately, otherwise we load the sheet and build every derived frame
+    the app uses. This frees non-home pages from depending on whatever keys
+    happened to be set by the last Home-page run.
+    """
+    required = (
+        'albums_df',
+        'reviews_df',
+        'deviation_df',
+        'listener_requester_df',
+        'album_stats_df',
+    )
+    if all(k in st.session_state for k in required):
+        return
+
+    df = load_sheet(sheets_doc_id)
+    listeners = get_listeners(df)
+    albums_df = build_albums_df(df)
+    reviews_df = build_reviews_df(df, listeners)
+    st.session_state['albums_df'] = albums_df
+    st.session_state['reviews_df'] = reviews_df
+    st.session_state['deviation_df'] = build_deviation_df(reviews_df)
+    st.session_state['listener_requester_df'] = build_listener_requester_df(
+        reviews_df, albums_df
+    )
+    st.session_state['album_stats_df'] = build_album_stats_df(
+        reviews_df, albums_df
+    )

--- a/pages/Listeners.py
+++ b/pages/Listeners.py
@@ -1,5 +1,5 @@
 import streamlit as st
-import pandas as pd
+
 import last_fm
 
 
@@ -23,26 +23,17 @@ def _display_scores_given(listener_requester_df, reviews_df, listener):
         "score"
     ].mean()
     given_scores["Average"] = avg_score_given
-    valid_scores = given_scores.loc[listener].dropna()
 
-    sorted_columns = valid_scores.argsort()[::-1]  # Sort remaining valid scores
+    valid_scores = given_scores.loc[listener].dropna()
+    sorted_columns = valid_scores.argsort()[::-1]
     sorted_given_scores = given_scores[
         valid_scores.index[sorted_columns]
     ].reset_index(drop=True)
 
-    # Calculate the average score the listener gave
-    avg_score_given = reviews_df[reviews_df["listener"] == listener][
-        "score"
-    ].mean()
-    # sorted_given_scores["Average"] = avg_score_given
-
     styled_given_scores = sorted_given_scores.style.format(
         precision=2
     ).background_gradient(axis=1, cmap="RdYlGn")
-    st.dataframe(
-        styled_given_scores,
-        hide_index=True,
-    )
+    st.dataframe(styled_given_scores, hide_index=True)
 
 
 def _display_scores_received(

--- a/pages/Stats.py
+++ b/pages/Stats.py
@@ -1,0 +1,451 @@
+"""
+Record Club Stats dashboard.
+
+A mix of leaderboards, quirky superlatives, and charts built entirely off the
+reviews/albums dataframes that the home page loaded into session state.
+"""
+import altair as alt
+import numpy as np
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="Stats - Records and Rebuttals", layout="wide")
+st.title("Record Club Stats")
+
+if "reviews_df" not in st.session_state or "albums_df" not in st.session_state:
+    st.error("No reviews data available. Please visit the main page first.")
+    st.stop()
+
+reviews_df: pd.DataFrame = st.session_state["reviews_df"].copy()
+albums_df: pd.DataFrame = st.session_state["albums_df"].copy()
+album_stats: pd.DataFrame = st.session_state.get("album_stats_df", pd.DataFrame())
+
+if reviews_df.empty or album_stats.empty:
+    st.warning("No reviews yet — nothing to stat.")
+    st.stop()
+
+
+# ---------------------------------------------------------------------------
+# Hero metrics
+# ---------------------------------------------------------------------------
+top_row = album_stats.sort_values("mean", ascending=False).iloc[0]
+bottom_row = album_stats.sort_values("mean", ascending=True).iloc[0]
+
+c1, c2, c3, c4, c5 = st.columns(5)
+c1.metric("Albums", len(album_stats))
+c2.metric("Reviews", len(reviews_df))
+c3.metric("Listeners", reviews_df["listener"].nunique())
+c4.metric("Club Average", f"{reviews_df['score'].mean():.2f}")
+c5.metric(
+    "Top Album",
+    f"{top_row['mean']:.2f}",
+    f"{top_row['artist']} — {top_row['album']}",
+)
+
+st.caption(
+    f"The club's lowest scoring record so far: **{bottom_row['artist']} — "
+    f"{bottom_row['album']}** at **{bottom_row['mean']:.2f}**."
+)
+
+st.divider()
+
+# ---------------------------------------------------------------------------
+# Score distribution
+# ---------------------------------------------------------------------------
+st.subheader("Score Distribution")
+
+dist_col, stat_col = st.columns([3, 1])
+with dist_col:
+    hist = (
+        alt.Chart(reviews_df)
+        .mark_bar(color="#e45756")
+        .encode(
+            x=alt.X(
+                "score:Q",
+                bin=alt.Bin(step=0.5),
+                title="Score",
+            ),
+            y=alt.Y("count()", title="Reviews"),
+            tooltip=[alt.Tooltip("count()", title="Reviews")],
+        )
+        .properties(height=260)
+    )
+    st.altair_chart(hist, use_container_width=True)
+
+with stat_col:
+    desc = reviews_df["score"].describe()
+    st.metric("Mean", f"{desc['mean']:.2f}")
+    st.metric("Median", f"{desc['50%']:.2f}")
+    st.metric("Std Dev", f"{desc['std']:.2f}")
+    perfect = (reviews_df["score"] >= 10).sum()
+    zeros = (reviews_df["score"] <= 0).sum()
+    st.metric("Perfect 10s", int(perfect))
+    st.metric("Zeros", int(zeros))
+
+
+# ---------------------------------------------------------------------------
+# Decade breakdown
+# ---------------------------------------------------------------------------
+if "decade" in album_stats.columns and album_stats["decade"].notna().any():
+    st.divider()
+    st.subheader("By Decade")
+
+    decade_df = (
+        album_stats.dropna(subset=["decade"])
+        .groupby("decade")
+        .agg(albums=("album", "count"), avg_score=("mean", "mean"))
+        .reset_index()
+    )
+    # Sort decades numerically when possible (handles "60s", "1960s", etc.)
+    decade_df["_sort_key"] = (
+        decade_df["decade"]
+        .astype(str)
+        .str.extract(r"(\d+)")
+        .astype(float)
+        .fillna(-1)
+    )
+    decade_df = decade_df.sort_values("_sort_key").drop(columns="_sort_key")
+    decade_df["avg_score"] = decade_df["avg_score"].round(2)
+
+    left, right = st.columns(2)
+    with left:
+        st.markdown("**Albums per decade**")
+        chart = (
+            alt.Chart(decade_df)
+            .mark_bar(color="#4c78a8")
+            .encode(
+                x=alt.X("decade:N", sort=list(decade_df["decade"]), title=None),
+                y=alt.Y("albums:Q", title="Albums"),
+                tooltip=["decade", "albums"],
+            )
+            .properties(height=260)
+        )
+        st.altair_chart(chart, use_container_width=True)
+    with right:
+        st.markdown("**Average score by decade**")
+        chart = (
+            alt.Chart(decade_df)
+            .mark_bar(color="#54a24b")
+            .encode(
+                x=alt.X("decade:N", sort=list(decade_df["decade"]), title=None),
+                y=alt.Y(
+                    "avg_score:Q",
+                    title="Avg score",
+                    scale=alt.Scale(zero=False),
+                ),
+                tooltip=["decade", "avg_score"],
+            )
+            .properties(height=260)
+        )
+        st.altair_chart(chart, use_container_width=True)
+
+
+# ---------------------------------------------------------------------------
+# Release year trend
+# ---------------------------------------------------------------------------
+if "release_year" in album_stats.columns and album_stats["release_year"].notna().any():
+    st.divider()
+    st.subheader("Does the Club Prefer Old or New?")
+
+    year_df = album_stats.dropna(subset=["release_year"]).copy()
+    year_df["release_year"] = pd.to_numeric(
+        year_df["release_year"], errors="coerce"
+    )
+    year_df = year_df.dropna(subset=["release_year"])
+
+    if not year_df.empty:
+        points = (
+            alt.Chart(year_df)
+            .mark_circle(size=90, opacity=0.75)
+            .encode(
+                x=alt.X(
+                    "release_year:Q",
+                    title="Release year",
+                    scale=alt.Scale(zero=False),
+                ),
+                y=alt.Y(
+                    "mean:Q",
+                    title="Average score",
+                    scale=alt.Scale(zero=False),
+                ),
+                color=alt.Color("mean:Q", scale=alt.Scale(scheme="redyellowgreen")),
+                tooltip=["artist", "album", "release_year", "mean"],
+            )
+        )
+        trend = (
+            alt.Chart(year_df)
+            .transform_regression("release_year", "mean")
+            .mark_line(color="#222", strokeDash=[4, 4])
+            .encode(x="release_year:Q", y="mean:Q")
+        )
+        st.altair_chart(
+            (points + trend).properties(height=340),
+            use_container_width=True,
+        )
+
+        # Correlation — does the club skew old or new?
+        corr = year_df[["release_year", "mean"]].corr().iloc[0, 1]
+        if pd.notna(corr):
+            if abs(corr) < 0.1:
+                verdict = "basically indifferent to release year"
+            elif corr > 0:
+                verdict = "slightly partial to **newer** albums"
+            else:
+                verdict = "slightly partial to **older** albums"
+            st.caption(
+                f"Release-year/score correlation is **{corr:+.2f}** — the club is "
+                f"{verdict}."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Top / bottom / divisive / unanimous
+# ---------------------------------------------------------------------------
+st.divider()
+st.subheader("Leaderboards")
+
+tab_top, tab_bottom, tab_div, tab_unan = st.tabs(
+    ["Top 10", "Bottom 10", "Most Divisive", "Most Unanimous"]
+)
+
+display_cols = ["artist", "album", "mean", "median", "std", "count"]
+if "requester" in album_stats.columns:
+    display_cols.insert(2, "requester")
+
+with tab_top:
+    top10 = album_stats.sort_values("mean", ascending=False).head(10)[display_cols]
+    st.dataframe(
+        top10.style.background_gradient(subset=["mean"], cmap="RdYlGn"),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+with tab_bottom:
+    bottom10 = album_stats.sort_values("mean", ascending=True).head(10)[
+        display_cols
+    ]
+    st.dataframe(
+        bottom10.style.background_gradient(subset=["mean"], cmap="RdYlGn"),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+with tab_div:
+    divisive = album_stats[album_stats["count"] >= 2].sort_values(
+        "std", ascending=False
+    ).head(10)[display_cols]
+    st.caption("Biggest score spread between listeners — the albums that started fights.")
+    st.dataframe(
+        divisive.style.background_gradient(subset=["std"], cmap="Reds"),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+with tab_unan:
+    unanimous = album_stats[album_stats["count"] >= 2].sort_values(
+        ["std", "mean"], ascending=[True, False]
+    ).head(10)[display_cols]
+    st.caption("Lowest score spread — the club's rare moments of harmony.")
+    st.dataframe(
+        unanimous.style.background_gradient(subset=["mean"], cmap="RdYlGn"),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Listener superlatives
+# ---------------------------------------------------------------------------
+st.divider()
+st.subheader("Listener Superlatives")
+
+listener_stats = (
+    reviews_df.groupby("listener")["score"]
+    .agg(["mean", "median", "std", "min", "max", "count"])
+    .reset_index()
+    .rename(
+        columns={
+            "mean": "avg",
+            "median": "median",
+            "std": "spread",
+            "min": "floor",
+            "max": "ceiling",
+            "count": "reviews",
+        }
+    )
+    .round(2)
+)
+
+harshest = listener_stats.sort_values("avg", ascending=True).iloc[0]
+kindest = listener_stats.sort_values("avg", ascending=False).iloc[0]
+most_consistent = listener_stats[listener_stats["reviews"] >= 2].sort_values(
+    "spread", ascending=True
+).iloc[0] if (listener_stats["reviews"] >= 2).any() else None
+most_volatile = listener_stats[listener_stats["reviews"] >= 2].sort_values(
+    "spread", ascending=False
+).iloc[0] if (listener_stats["reviews"] >= 2).any() else None
+most_active = listener_stats.sort_values("reviews", ascending=False).iloc[0]
+
+cols = st.columns(5)
+cols[0].metric("Harshest Critic", harshest["listener"], f"avg {harshest['avg']:.2f}")
+cols[1].metric("Most Generous", kindest["listener"], f"avg {kindest['avg']:.2f}")
+if most_consistent is not None:
+    cols[2].metric(
+        "Most Consistent",
+        most_consistent["listener"],
+        f"σ {most_consistent['spread']:.2f}",
+    )
+if most_volatile is not None:
+    cols[3].metric(
+        "Most All-Over-the-Place",
+        most_volatile["listener"],
+        f"σ {most_volatile['spread']:.2f}",
+    )
+cols[4].metric(
+    "Most Active",
+    most_active["listener"],
+    f"{int(most_active['reviews'])} reviews",
+)
+
+st.markdown("**Full listener breakdown**")
+st.dataframe(
+    listener_stats.style.background_gradient(subset=["avg"], cmap="RdYlGn")
+    .background_gradient(subset=["spread"], cmap="Reds")
+    .format(precision=2),
+    hide_index=True,
+    use_container_width=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Requester leaderboard — who picks the best records?
+# ---------------------------------------------------------------------------
+if "requester" in album_stats.columns and album_stats["requester"].notna().any():
+    st.divider()
+    st.subheader("Who Picks the Best Records?")
+
+    requester_stats = (
+        album_stats.dropna(subset=["requester"])
+        .groupby("requester")
+        .agg(
+            picks=("album", "count"),
+            avg_reception=("mean", "mean"),
+            best=("mean", "max"),
+            worst=("mean", "min"),
+        )
+        .reset_index()
+        .round(2)
+        .sort_values("avg_reception", ascending=False)
+    )
+    st.dataframe(
+        requester_stats.style.background_gradient(
+            subset=["avg_reception"], cmap="RdYlGn"
+        ),
+        hide_index=True,
+        use_container_width=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cumulative timeline
+# ---------------------------------------------------------------------------
+if (
+    "date" in albums_df.columns
+    and pd.api.types.is_datetime64_any_dtype(albums_df["date"])
+    and albums_df["date"].notna().any()
+):
+    st.divider()
+    st.subheader("Club Timeline")
+
+    timeline = albums_df.dropna(subset=["date"]).sort_values("date").copy()
+    timeline["cumulative"] = np.arange(1, len(timeline) + 1)
+
+    # Merge in mean scores to color the timeline
+    timeline = timeline.merge(
+        album_stats[["artist", "album", "mean"]],
+        on=["artist", "album"],
+        how="left",
+    )
+
+    line = (
+        alt.Chart(timeline)
+        .mark_line(color="#4c78a8", strokeWidth=2)
+        .encode(
+            x=alt.X("date:T", title=None),
+            y=alt.Y("cumulative:Q", title="Albums reviewed"),
+        )
+    )
+    dots = (
+        alt.Chart(timeline)
+        .mark_circle(size=80)
+        .encode(
+            x="date:T",
+            y="cumulative:Q",
+            color=alt.Color(
+                "mean:Q",
+                scale=alt.Scale(scheme="redyellowgreen"),
+                title="Score",
+            ),
+            tooltip=["date:T", "artist", "album", "mean"],
+        )
+    )
+    st.altair_chart((line + dots).properties(height=320), use_container_width=True)
+
+
+# ---------------------------------------------------------------------------
+# Track-level fun
+# ---------------------------------------------------------------------------
+st.divider()
+st.subheader("Tracks People Can't Stop Talking About")
+
+fav_col, least_col = st.columns(2)
+
+with fav_col:
+    st.markdown("**Most name-dropped as favorite**")
+    fav_tracks = (
+        reviews_df.dropna(subset=["favorite_track"])
+        .groupby(["artist", "album", "favorite_track"])
+        .size()
+        .reset_index(name="votes")
+        .sort_values("votes", ascending=False)
+        .head(10)
+    )
+    st.dataframe(fav_tracks, hide_index=True, use_container_width=True)
+
+with least_col:
+    st.markdown("**Most name-dropped as least favorite**")
+    least_tracks = (
+        reviews_df.dropna(subset=["least_favorite_track"])
+        .groupby(["artist", "album", "least_favorite_track"])
+        .size()
+        .reset_index(name="votes")
+        .sort_values("votes", ascending=False)
+        .head(10)
+    )
+    st.dataframe(least_tracks, hide_index=True, use_container_width=True)
+
+
+# ---------------------------------------------------------------------------
+# Hot takes — biggest deviation from club average on a single album
+# ---------------------------------------------------------------------------
+st.divider()
+st.subheader("Hottest Takes")
+st.caption(
+    "Where a single listener's score strayed the furthest from the rest of the "
+    "club on one album."
+)
+
+takes = reviews_df.merge(
+    album_stats[["artist", "album", "mean"]], on=["artist", "album"]
+)
+takes["delta"] = takes["score"] - takes["mean"]
+takes["abs_delta"] = takes["delta"].abs()
+hot_takes = takes.sort_values("abs_delta", ascending=False).head(10)[
+    ["listener", "artist", "album", "score", "mean", "delta"]
+].rename(columns={"mean": "club_avg"})
+st.dataframe(
+    hot_takes.style.background_gradient(subset=["delta"], cmap="RdBu")
+    .format(precision=2),
+    hide_index=True,
+    use_container_width=True,
+)

--- a/pages/Stats.py
+++ b/pages/Stats.py
@@ -112,6 +112,8 @@ if "decade" in album_stats.columns and album_stats["decade"].notna().any():
     )
     decade_df = decade_df.sort_values("_sort_key").drop(columns="_sort_key")
     decade_df["avg_score"] = decade_df["avg_score"].round(2)
+    score_min = decade_df["avg_score"].min() - 5
+    score_max = decade_df["avg_score"].max() + 5
 
     left, right = st.columns(2)
     with left:
@@ -137,7 +139,7 @@ if "decade" in album_stats.columns and album_stats["decade"].notna().any():
                 y=alt.Y(
                     "avg_score:Q",
                     title="Avg score",
-                    scale=alt.Scale(zero=False),
+                    scale=alt.Scale(domain=[score_min, score_max]),
                 ),
                 tooltip=["decade", "avg_score"],
             )
@@ -181,7 +183,7 @@ if "release_year" in album_stats.columns and album_stats["release_year"].notna()
         trend = (
             alt.Chart(year_df)
             .transform_regression("release_year", "mean")
-            .mark_line(color="#222", strokeDash=[4, 4])
+            .mark_line(color="#e45756", strokeWidth=3)
             .encode(x="release_year:Q", y="mean:Q")
         )
         st.altair_chart(
@@ -396,39 +398,6 @@ if (
         )
     )
     st.altair_chart((line + dots).properties(height=320), use_container_width=True)
-
-
-# ---------------------------------------------------------------------------
-# Track-level fun
-# ---------------------------------------------------------------------------
-st.divider()
-st.subheader("Tracks People Can't Stop Talking About")
-
-fav_col, least_col = st.columns(2)
-
-with fav_col:
-    st.markdown("**Most name-dropped as favorite**")
-    fav_tracks = (
-        reviews_df.dropna(subset=["favorite_track"])
-        .groupby(["artist", "album", "favorite_track"])
-        .size()
-        .reset_index(name="votes")
-        .sort_values("votes", ascending=False)
-        .head(10)
-    )
-    st.dataframe(fav_tracks, hide_index=True, use_container_width=True)
-
-with least_col:
-    st.markdown("**Most name-dropped as least favorite**")
-    least_tracks = (
-        reviews_df.dropna(subset=["least_favorite_track"])
-        .groupby(["artist", "album", "least_favorite_track"])
-        .size()
-        .reset_index(name="votes")
-        .sort_values("votes", ascending=False)
-        .head(10)
-    )
-    st.dataframe(least_tracks, hide_index=True, use_container_width=True)
 
 
 # ---------------------------------------------------------------------------

--- a/pages/Stats.py
+++ b/pages/Stats.py
@@ -9,18 +9,24 @@ import numpy as np
 import pandas as pd
 import streamlit as st
 
+import data
+
 st.set_page_config(page_title="Stats - Records and Rebuttals", layout="wide")
 st.title("Record Club Stats")
 
-if "reviews_df" not in st.session_state or "albums_df" not in st.session_state:
-    st.error("No reviews data available. Please visit the main page first.")
-    st.stop()
+data.ensure_session_state(st.secrets["SHEETS_DOC_ID"])
 
 reviews_df: pd.DataFrame = st.session_state["reviews_df"].copy()
 albums_df: pd.DataFrame = st.session_state["albums_df"].copy()
-album_stats: pd.DataFrame = st.session_state.get("album_stats_df", pd.DataFrame())
+album_stats: pd.DataFrame = st.session_state["album_stats_df"].copy()
 
-if reviews_df.empty or album_stats.empty:
+# Defensive: if album_stats_df was stashed by a prior (pre-update) run,
+# rebuild it rather than bailing with an empty page.
+if album_stats.empty and not reviews_df.empty:
+    album_stats = data.build_album_stats_df(reviews_df, albums_df)
+    st.session_state["album_stats_df"] = album_stats
+
+if reviews_df.empty:
     st.warning("No reviews yet — nothing to stat.")
     st.stop()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    # Streamlit's caching decorators warn when run outside the app; harmless.
+    "ignore::UserWarning:streamlit.runtime.caching",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-cov==6.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared fixtures for the test suite.
+
+Adds the project root to ``sys.path`` so tests can import the top-level
+modules (``data``, ``last_fm``) the same way the Streamlit app does.
+"""
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def raw_sheet_df() -> pd.DataFrame:
+    """A DataFrame shaped like the Google Sheet ``load_sheet`` returns.
+
+    The real sheet has an unnamed whitespace-only date column, three
+    columns per listener (``Name``, ``Name.1``, ``Name.2`` for score,
+    favorite track, least favorite track), and an ``Average`` column at
+    the end.
+    """
+    return pd.DataFrame(
+        {
+            " ": ["2024-01-01", "2024-02-01", "2024-03-01"],
+            "Requester": ["Alice", "Bob", "Carol"],
+            "Artist": ["Beatles", "Stones", "Zeppelin"],
+            "Album": ["Abbey Road", "Let It Bleed", "IV"],
+            "Release Year": [1969, 1969, 1971],
+            "Decade": ["60s", "60s", "70s"],
+            "Alice": [9, 8, 7],
+            "Alice.1": ["Come Together", "Gimme Shelter", "Black Dog"],
+            "Alice.2": ["Octopus's Garden", None, "Four Sticks"],
+            "Bob": [7, 9, 10],
+            "Bob.1": ["Something", "Monkey Man", "Stairway to Heaven"],
+            "Bob.2": [None, None, None],
+            "Carol": [8, 7, 9],
+            "Carol.1": ["Here Comes the Sun", "Midnight Rambler", "Rock and Roll"],
+            "Carol.2": [None, None, None],
+            "Average": [8.0, 8.0, 8.67],
+        }
+    )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -53,13 +53,14 @@ class TestBuildAlbumsDf:
     def test_selects_and_renames_columns(self, raw_sheet_df):
         df = data._normalize_columns(raw_sheet_df)
         albums = data.build_albums_df(df)
-        assert list(albums.columns) == [
+        assert set(albums.columns) == {
             "artist",
             "album",
             "requester",
             "date",
             "release_year",
-        ]
+            "decade",
+        }
         assert len(albums) == 3
         assert albums.iloc[0]["artist"] == "Beatles"
         assert albums.iloc[0]["album"] == "Abbey Road"
@@ -69,6 +70,49 @@ class TestBuildAlbumsDf:
         albums = data.build_albums_df(df)
         assert "release_year" not in albums.columns
         assert "artist" in albums.columns
+
+    def test_parses_date_column_to_datetime(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        albums = data.build_albums_df(df)
+        assert pd.api.types.is_datetime64_any_dtype(albums["date"])
+
+    def test_derives_decade_from_release_year_when_missing(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df).drop(columns=["Decade"])
+        albums = data.build_albums_df(df)
+        assert "decade" in albums.columns
+        # Beatles/Abbey Road (1969) -> "1960s"
+        assert albums.iloc[0]["decade"] == "1960s"
+
+    def test_uses_sheet_decade_column_when_present(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        albums = data.build_albums_df(df)
+        # Sheet fixture literally says "60s" — trust the sheet, don't overwrite.
+        assert albums.iloc[0]["decade"] == "60s"
+
+
+class TestBuildAlbumStatsDf:
+    def test_aggregates_album_scores_and_joins_metadata(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        reviews = data.build_reviews_df(df, listeners)
+        albums = data.build_albums_df(df)
+        stats = data.build_album_stats_df(reviews, albums)
+
+        assert {"mean", "median", "std", "count", "requester", "decade"} <= set(
+            stats.columns
+        )
+        abbey = stats[stats["album"] == "Abbey Road"].iloc[0]
+        # (9 + 7 + 8) / 3 = 8.0
+        assert abbey["mean"] == pytest.approx(8.0)
+        assert abbey["count"] == 3
+
+    def test_empty_reviews_returns_empty_frame(self):
+        empty_reviews = pd.DataFrame(
+            columns=["listener", "artist", "album", "score"]
+        )
+        empty_albums = pd.DataFrame(columns=["artist", "album", "requester"])
+        stats = data.build_album_stats_df(empty_reviews, empty_albums)
+        assert stats.empty
 
 
 class TestBuildReviewsDf:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,191 @@
+"""Tests for the pure data-munging helpers in ``data.py``."""
+import numpy as np
+import pandas as pd
+import pytest
+
+import data
+
+
+class TestNormalizeColumns:
+    def test_renames_whitespace_column_to_date(self):
+        df = pd.DataFrame({" ": ["2024-01-01"], "Artist": ["Beatles"]})
+        result = data._normalize_columns(df)
+        assert "Date" in result.columns
+        assert " " not in result.columns
+
+    def test_leaves_existing_date_column_alone(self):
+        df = pd.DataFrame(
+            {"Date": ["2024-01-01"], " ": ["junk"], "Artist": ["Beatles"]}
+        )
+        result = data._normalize_columns(df)
+        # Existing Date column wins, whitespace column is untouched.
+        assert list(result.columns) == ["Date", " ", "Artist"]
+
+    def test_noop_when_no_whitespace_column(self):
+        df = pd.DataFrame({"Artist": ["Beatles"], "Album": ["Abbey Road"]})
+        result = data._normalize_columns(df)
+        pd.testing.assert_frame_equal(result, df)
+
+
+class TestGetListeners:
+    def test_detects_listeners_between_metadata_and_average(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        assert data.get_listeners(df) == ["Alice", "Bob", "Carol"]
+
+    def test_excludes_favorite_and_least_favorite_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        assert not any(name.endswith((".1", ".2")) for name in listeners)
+
+    def test_excludes_unnamed_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.insert(len(df.columns) - 1, "Unnamed: 42", [None] * len(df))
+        listeners = data.get_listeners(df)
+        assert "Unnamed: 42" not in listeners
+
+    def test_raises_if_average_column_missing(self):
+        df = pd.DataFrame({"Artist": ["Beatles"], "Alice": [8]})
+        with pytest.raises(ValueError):
+            data.get_listeners(df)
+
+
+class TestBuildAlbumsDf:
+    def test_selects_and_renames_columns(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        albums = data.build_albums_df(df)
+        assert list(albums.columns) == [
+            "artist",
+            "album",
+            "requester",
+            "date",
+            "release_year",
+        ]
+        assert len(albums) == 3
+        assert albums.iloc[0]["artist"] == "Beatles"
+        assert albums.iloc[0]["album"] == "Abbey Road"
+
+    def test_works_without_release_year_column(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df).drop(columns=["Release Year"])
+        albums = data.build_albums_df(df)
+        assert "release_year" not in albums.columns
+        assert "artist" in albums.columns
+
+
+class TestBuildReviewsDf:
+    def test_flattens_wide_sheet_into_long_reviews(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        reviews = data.build_reviews_df(df, listeners)
+
+        # 3 albums x 3 listeners = 9 reviews
+        assert len(reviews) == 9
+        assert set(reviews.columns) == {
+            "listener",
+            "artist",
+            "album",
+            "score",
+            "favorite_track",
+            "least_favorite_track",
+        }
+
+    def test_captures_favorite_and_least_favorite_tracks(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+
+        alice_zep = reviews[
+            (reviews["listener"] == "Alice") & (reviews["album"] == "IV")
+        ].iloc[0]
+        assert alice_zep["favorite_track"] == "Black Dog"
+        assert alice_zep["least_favorite_track"] == "Four Sticks"
+
+    def test_skips_rows_with_missing_artist_or_album(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.loc[1, "Artist"] = None
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        assert "Let It Bleed" not in reviews["album"].tolist()
+
+    def test_skips_reviews_with_null_scores(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        df.loc[0, "Alice"] = None
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        alice_abbey = reviews[
+            (reviews["listener"] == "Alice") & (reviews["album"] == "Abbey Road")
+        ]
+        assert alice_abbey.empty
+
+
+class TestBuildDeviationDf:
+    def test_returns_square_matrix_plus_average_row(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        listeners = sorted(reviews["listener"].unique())
+        assert sorted(deviation.columns.tolist()) == listeners
+        assert "average" in deviation.index
+        # The non-average rows are the listener names.
+        non_avg = [i for i in deviation.index if i != "average"]
+        assert sorted(non_avg) == listeners
+
+    def test_diagonal_is_zero(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        for listener in reviews["listener"].unique():
+            assert deviation.loc[listener, listener] == 0
+
+    def test_deviation_is_symmetric(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        reviews = data.build_reviews_df(df, data.get_listeners(df))
+        deviation = data.build_deviation_df(reviews)
+
+        listeners = reviews["listener"].unique()
+        for a in listeners:
+            for b in listeners:
+                assert deviation.loc[a, b] == deviation.loc[b, a]
+
+    def test_known_rmse_value(self):
+        # Alice and Bob both rate two albums; Alice=[10, 6], Bob=[8, 8].
+        # Differences: 2, -2. RMSE = sqrt((4+4)/2) = 2.0
+        reviews = pd.DataFrame(
+            [
+                {"listener": "Alice", "artist": "X", "album": "A", "score": 10},
+                {"listener": "Alice", "artist": "X", "album": "B", "score": 6},
+                {"listener": "Bob", "artist": "X", "album": "A", "score": 8},
+                {"listener": "Bob", "artist": "X", "album": "B", "score": 8},
+            ]
+        )
+        deviation = data.build_deviation_df(reviews)
+        assert deviation.loc["Alice", "Bob"] == pytest.approx(2.0)
+
+
+class TestBuildListenerRequesterDf:
+    def test_produces_pivot_keyed_by_listener_and_requester(self, raw_sheet_df):
+        df = data._normalize_columns(raw_sheet_df)
+        listeners = data.get_listeners(df)
+        reviews = data.build_reviews_df(df, listeners)
+        albums = data.build_albums_df(df)
+
+        pivot = data.build_listener_requester_df(reviews, albums)
+
+        assert pivot.index.name == "listener"
+        assert pivot.columns.name == "requester"
+        assert set(pivot.index) <= {"Alice", "Bob", "Carol"}
+        assert set(pivot.columns) <= {"Alice", "Bob", "Carol"}
+
+    def test_values_are_mean_scores_rounded_to_one_decimal(self):
+        reviews = pd.DataFrame(
+            [
+                {"listener": "Alice", "artist": "X", "album": "A", "score": 9},
+                {"listener": "Alice", "artist": "X", "album": "B", "score": 6},
+            ]
+        )
+        albums = pd.DataFrame(
+            [
+                {"artist": "X", "album": "A", "requester": "Bob"},
+                {"artist": "X", "album": "B", "requester": "Bob"},
+            ]
+        )
+        pivot = data.build_listener_requester_df(reviews, albums)
+        assert pivot.loc["Alice", "Bob"] == pytest.approx(7.5)

--- a/tests/test_last_fm.py
+++ b/tests/test_last_fm.py
@@ -1,0 +1,155 @@
+"""Tests for the Last.fm API client and ``Album`` response parser."""
+from unittest.mock import patch, MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+import last_fm
+
+
+@pytest.fixture
+def album_response():
+    """A trimmed-down copy of a real ``album.getinfo`` response."""
+    return {
+        "album": {
+            "artist": "Radiohead",
+            "name": "OK Computer",
+            "image": [
+                {"#text": "https://img/small.png", "size": "small"},
+                {"#text": "https://img/medium.png", "size": "medium"},
+                {"#text": "https://img/large.png", "size": "large"},
+                {"#text": "https://img/xl.png", "size": "extralarge"},
+            ],
+            "tracks": {
+                "track": [
+                    {
+                        "name": "Airbag",
+                        "duration": "284",
+                        "@attr": {"rank": "1"},
+                    },
+                    {
+                        "name": "Paranoid Android",
+                        "duration": "383",
+                        "@attr": {"rank": "2"},
+                    },
+                ]
+            },
+            "tags": {
+                "tag": [
+                    {"name": "alternative"},
+                    {"name": "rock"},
+                ]
+            },
+            "listeners": "1234567",
+            "playcount": "98765432",
+        }
+    }
+
+
+class TestAlbum:
+    def test_parses_basic_fields(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.artist == "Radiohead"
+        assert album.title == "OK Computer"
+        assert album.listeners == "1234567"
+        assert album.playcount == "98765432"
+
+    def test_picks_large_image(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.image_url == "https://img/large.png"
+
+    def test_parses_tracks_with_rank_and_duration(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.tracks == [
+            {"title": "Airbag", "duration": "284", "track_number": "1"},
+            {
+                "title": "Paranoid Android",
+                "duration": "383",
+                "track_number": "2",
+            },
+        ]
+
+    def test_parses_tags(self, album_response):
+        album = last_fm.Album(album_response)
+        assert album.tags == [{"name": "alternative"}, {"name": "rock"}]
+
+    def test_handles_missing_tags(self, album_response):
+        album_response["album"].pop("tags")
+        album = last_fm.Album(album_response)
+        assert album.tags == []
+
+    def test_handles_empty_response(self):
+        album = last_fm.Album({})
+        assert album.artist is None
+        assert album.title is None
+        assert album.tracks == []
+        assert album.tags == []
+        assert album.image_url is None
+
+    def test_image_url_is_none_when_no_large_image(self, album_response):
+        album_response["album"]["image"] = [
+            {"#text": "https://img/small.png", "size": "small"}
+        ]
+        album = last_fm.Album(album_response)
+        assert album.image_url is None
+
+
+class TestLastFmClient:
+    def test_build_url_adds_api_key_method_and_format(self):
+        client = last_fm.LastFmClient("secret-key")
+        url = client._build_url(
+            "album.getinfo", {"artist": "Radiohead", "album": "OK Computer"}
+        )
+
+        parsed = urlparse(url)
+        assert parsed.scheme == "https"
+        assert parsed.netloc == "ws.audioscrobbler.com"
+        assert parsed.path == "/2.0/"
+
+        qs = parse_qs(parsed.query)
+        assert qs["api_key"] == ["secret-key"]
+        assert qs["method"] == ["album.getinfo"]
+        assert qs["format"] == ["json"]
+        assert qs["artist"] == ["Radiohead"]
+        assert qs["album"] == ["OK Computer"]
+
+    def test_get_album_calls_api_and_returns_album(self, album_response):
+        client = last_fm.LastFmClient("k")
+        with patch.object(last_fm, "_make_call", return_value=album_response) as mk:
+            album = client.get_album("Radiohead", "OK Computer")
+
+        mk.assert_called_once()
+        called_url = mk.call_args[0][0]
+        qs = parse_qs(urlparse(called_url).query)
+        assert qs["artist"] == ["Radiohead"]
+        assert qs["album"] == ["OK Computer"]
+        assert qs["autocorrect"] == ["1"]
+        assert isinstance(album, last_fm.Album)
+        assert album.title == "OK Computer"
+
+    def test_get_album_returns_none_when_api_returns_none(self):
+        client = last_fm.LastFmClient("k")
+        with patch.object(last_fm, "_make_call", return_value=None):
+            assert client.get_album("X", "Y") is None
+
+    def test_make_call_raises_for_status(self):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = Exception("boom")
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            with pytest.raises(Exception, match="boom"):
+                last_fm._make_call("https://example.com")
+
+    def test_make_call_returns_parsed_json(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status.return_value = None
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            assert last_fm._make_call("https://example.com") == {"ok": True}
+
+    def test_get_album_art_fetches_image_bytes(self, album_response):
+        album = last_fm.Album(album_response)
+        mock_response = MagicMock()
+        mock_response.content = b"\x89PNG fake bytes"
+        with patch.object(last_fm.requests, "get", return_value=mock_response):
+            buf = album.get_album_art()
+        assert buf.read() == b"\x89PNG fake bytes"


### PR DESCRIPTION
Pull the top tags for each album from Last.fm (via the existing
album.getinfo client), normalize them, and drop personal/noise tags
(favorites, seen live, countries, decades) so the Stats page can show
what the club actually listens to.

New Stats page section: most-common genres, best-received genres,
a popularity-vs-reception scatter, and a per-album tag table.